### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/send_message.py
+++ b/send_message.py
@@ -11,4 +11,4 @@ pywhatkit.sendwhatmsg_instantly(
     tab_close=True  # close tab after sending
 )
 
-print(f"WhatsApp message sent successfully to {phone_number}!")
+print("WhatsApp message sent successfully!")


### PR DESCRIPTION
Potential fix for [https://github.com/klakshman318/pywhatkit-whatsapp-integration/security/code-scanning/2](https://github.com/klakshman318/pywhatkit-whatsapp-integration/security/code-scanning/2)

To fix the problem, we should avoid logging the sensitive `phone_number` directly. Instead, we can log a generic success message that does not include the phone number. This way, we maintain the functionality of logging the success of the message sending operation without exposing sensitive information.

We need to modify the log statement on line 14 in the `send_message.py` file to remove the `phone_number` from the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
